### PR TITLE
Add sample chatbot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,49 @@ POST /signin     # authenticate and receive a token
 
 These endpoints should be implemented in the backend Express app and can be
 expanded for additional functionality.
+
+## Building a Chatbot with a Custom GPT
+A custom GPT can be used to power a chatbot in the Angular app. The GPT should be configured with the backend's OpenAPI definition so that it can call endpoints such as `/userinfo` to fetch data. The basic flow is:
+1. User interacts with the chatbot UI in the Angular app.
+2. The Angular service sends the user message to the custom GPT endpoint.
+3. The GPT decides whether to call any backend action, for example by fetching `/userinfo`.
+4. The response from the backend is incorporated into the GPT's reply, which is then displayed to the user.
+
+### Sample `/userinfo` Route
+Below is an example Express route that returns dummy user information. In a real application this would query a database.
+```javascript
+// backend/server.js
+const express = require('express');
+const app = express();
+
+app.get('/userinfo', (req, res) => {
+  // Example static user data
+  res.json({ id: 1, username: 'demo', email: 'demo@example.com' });
+});
+
+app.listen(3000, () => {
+  console.log('API server listening on port 3000');
+});
+```
+
+### Angular Chat Service (simplified)
+```ts
+// frontend/src/app/chat.service.ts
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ChatService {
+  constructor(private http: HttpClient) {}
+
+  getUserInfo() {
+    return this.http.get('/userinfo');
+  }
+
+  sendMessage(message: string) {
+    // Send message to your custom GPT endpoint
+    // and return the observable response
+    return this.http.post('/chat', { message });
+  }
+}
+```

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+
+app.get('/userinfo', (req, res) => {
+  // Example static user data
+  res.json({ id: 1, username: 'demo', email: 'demo@example.com' });
+});
+
+app.listen(3000, () => {
+  console.log('API server listening on port 3000');
+});

--- a/frontend/src/app/chat.service.ts
+++ b/frontend/src/app/chat.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ChatService {
+  constructor(private http: HttpClient) {}
+
+  getUserInfo() {
+    return this.http.get('/userinfo');
+  }
+
+  sendMessage(message: string) {
+    // Send message to your custom GPT endpoint
+    return this.http.post('/chat', { message });
+  }
+}


### PR DESCRIPTION
## Summary
- expand README with instructions for using a custom GPT
- add example backend `/userinfo` route
- add basic Angular chat service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c030e9114832ba404903cb14a2a0e